### PR TITLE
Allow funders to withdraw any token

### DIFF
--- a/contracts/MatchPayouts.sol
+++ b/contracts/MatchPayouts.sol
@@ -62,7 +62,7 @@ contract MatchPayouts {
   event Funded();
 
   /// @dev Emitted when the funder reclaims the funds in this contract
-  event FundingWithdrawn();
+  event FundingWithdrawn(IERC20 token, uint256 amount);
 
   /// @dev Emitted when a payout `amount` is added to the `recipient`'s payout total
   event PayoutAdded(address recipient, uint256 amount);
@@ -129,11 +129,13 @@ contract MatchPayouts {
    * @dev Escape hatch, intended to be used if the payout mapping is finalized incorrectly. In this
    * case a new MatchPayouts contract can be deployed and that one will be used instead
    * @dev We trust the funder, which is why they are allowed to withdraw funds at any time
+   * @param _token Address of token to withdraw from this contract
    */
-  function withdrawFunding() external {
+  function withdrawFunding(IERC20 _token) external {
     require(msg.sender == funder, "MatchPayouts: caller is not the funder");
-    dai.safeTransfer(funder, dai.balanceOf(address(this)));
-    emit FundingWithdrawn();
+    uint256 _balance = _token.balanceOf(address(this));
+    _token.safeTransfer(funder, _balance);
+    emit FundingWithdrawn(_token, _balance);
   }
 
   /**

--- a/test/MatchPayouts.behavior.ts
+++ b/test/MatchPayouts.behavior.ts
@@ -26,7 +26,7 @@ export function shouldBehaveLikeMatchPayouts(): void {
     });
 
     it("restricts who is allowed to withdraw funders' DAI from the contract", async function () {
-      const tx = this.matchPayouts.connect(this.signers.evilUser).withdrawFunding();
+      const tx = this.matchPayouts.connect(this.signers.evilUser).withdrawFunding(this.dai.address);
       await expect(tx).to.be.revertedWith('MatchPayouts: caller is not the funder');
     });
 
@@ -104,8 +104,8 @@ export function shouldBehaveLikeMatchPayouts(): void {
       expect(await this.dai.balanceOf(this.accounts.funder)).to.equal('0');
 
       // Withdraw funds
-      const tx = this.matchPayouts.connect(this.signers.funder).withdrawFunding();
-      await expect(tx).to.emit(this.matchPayouts, 'FundingWithdrawn');
+      const tx = this.matchPayouts.connect(this.signers.funder).withdrawFunding(this.dai.address);
+      await expect(tx).to.emit(this.matchPayouts, 'FundingWithdrawn').withArgs(this.dai.address, funderAmount);
       expect(await this.dai.balanceOf(this.matchPayouts.address)).to.equal('0');
       expect(await this.dai.balanceOf(this.accounts.funder)).to.equal(funderAmount);
     });


### PR DESCRIPTION
Allows funders to withdraw any token, not just DAI. This solves two problems:
- `dai` address is set incorrectly at construction
- Funder sends the wrong tokens to the contract